### PR TITLE
[Docs] Swagger 초기 세팅

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,11 +27,57 @@
                 "passport-local": "^1.0.0",
                 "prisma": "^6.18.0",
                 "swagger-autogen": "^2.23.7",
+                "swagger-jsdoc": "^6.2.8",
                 "swagger-ui-express": "^5.0.1"
             },
             "devDependencies": {
                 "nodemon": "^3.1.10"
             }
+        },
+        "node_modules/@apidevtools/json-schema-ref-parser": {
+            "version": "9.1.2",
+            "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.1.2.tgz",
+            "integrity": "sha512-r1w81DpR+KyRWd3f+rk6TNqMgedmAxZP5v5KWlXQWlgMUUtyEJch0DKEci1SorPMiSeM8XPl7MZ3miJ60JIpQg==",
+            "dependencies": {
+                "@jsdevtools/ono": "^7.1.3",
+                "@types/json-schema": "^7.0.6",
+                "call-me-maybe": "^1.0.1",
+                "js-yaml": "^4.1.0"
+            }
+        },
+        "node_modules/@apidevtools/openapi-schemas": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
+            "integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@apidevtools/swagger-methods": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
+            "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg=="
+        },
+        "node_modules/@apidevtools/swagger-parser": {
+            "version": "10.0.3",
+            "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.3.tgz",
+            "integrity": "sha512-sNiLY51vZOmSPFZA5TF35KZ2HbgYklQnTSDnkghamzLb3EkNtcQnrBQEj5AOCxHpTtXpqMCRM1CrmV2rG6nw4g==",
+            "dependencies": {
+                "@apidevtools/json-schema-ref-parser": "^9.0.6",
+                "@apidevtools/openapi-schemas": "^2.0.4",
+                "@apidevtools/swagger-methods": "^3.0.2",
+                "@jsdevtools/ono": "^7.1.3",
+                "call-me-maybe": "^1.0.1",
+                "z-schema": "^5.0.1"
+            },
+            "peerDependencies": {
+                "openapi-types": ">=7"
+            }
+        },
+        "node_modules/@jsdevtools/ono": {
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+            "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
         },
         "node_modules/@prisma/client": {
             "version": "6.19.1",
@@ -125,6 +171,11 @@
             "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
             "license": "MIT"
         },
+        "node_modules/@types/json-schema": {
+            "version": "7.0.15",
+            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+            "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
+        },
         "node_modules/accepts": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -172,6 +223,11 @@
             "engines": {
                 "node": ">= 8"
             }
+        },
+        "node_modules/argparse": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
         },
         "node_modules/balanced-match": {
             "version": "1.0.2",
@@ -415,6 +471,11 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/call-me-maybe": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+            "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ=="
+        },
         "node_modules/chokidar": {
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -447,6 +508,14 @@
             "license": "MIT",
             "dependencies": {
                 "consola": "^3.2.3"
+            }
+        },
+        "node_modules/commander": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
+            "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==",
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/compressible": {
@@ -610,6 +679,17 @@
             "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
             "license": "MIT"
         },
+        "node_modules/doctrine": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+            "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+            "dependencies": {
+                "esutils": "^2.0.2"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
         "node_modules/dotenv": {
             "version": "17.2.3",
             "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
@@ -714,6 +794,14 @@
             "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
             "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
             "license": "MIT"
+        },
+        "node_modules/esutils": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+            "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
         "node_modules/etag": {
             "version": "1.8.1",
@@ -1227,6 +1315,17 @@
                 "jiti": "lib/jiti-cli.mjs"
             }
         },
+        "node_modules/js-yaml": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+            "dependencies": {
+                "argparse": "^2.0.1"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
+            }
+        },
         "node_modules/json5": {
             "version": "2.2.3",
             "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -1288,6 +1387,12 @@
                 "safe-buffer": "^5.0.1"
             }
         },
+        "node_modules/lodash.get": {
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+            "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+            "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead."
+        },
         "node_modules/lodash.includes": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -1299,6 +1404,12 @@
             "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
             "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
             "license": "MIT"
+        },
+        "node_modules/lodash.isequal": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+            "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+            "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead."
         },
         "node_modules/lodash.isinteger": {
             "version": "4.0.4",
@@ -1323,6 +1434,11 @@
             "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
             "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
             "license": "MIT"
+        },
+        "node_modules/lodash.mergewith": {
+            "version": "4.6.2",
+            "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+            "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
         },
         "node_modules/lodash.once": {
             "version": "4.1.1",
@@ -1611,6 +1727,12 @@
             "dependencies": {
                 "wrappy": "1"
             }
+        },
+        "node_modules/openapi-types": {
+            "version": "12.1.3",
+            "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+            "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+            "peer": true
         },
         "node_modules/parseurl": {
             "version": "1.3.3",
@@ -2200,6 +2322,56 @@
                 "json5": "^2.2.3"
             }
         },
+        "node_modules/swagger-jsdoc": {
+            "version": "6.2.8",
+            "resolved": "https://registry.npmjs.org/swagger-jsdoc/-/swagger-jsdoc-6.2.8.tgz",
+            "integrity": "sha512-VPvil1+JRpmJ55CgAtn8DIcpBs0bL5L3q5bVQvF4tAW/k/9JYSj7dCpaYCAv5rufe0vcCbBRQXGvzpkWjvLklQ==",
+            "dependencies": {
+                "commander": "6.2.0",
+                "doctrine": "3.0.0",
+                "glob": "7.1.6",
+                "lodash.mergewith": "^4.6.2",
+                "swagger-parser": "^10.0.3",
+                "yaml": "2.0.0-1"
+            },
+            "bin": {
+                "swagger-jsdoc": "bin/swagger-jsdoc.js"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
+        "node_modules/swagger-jsdoc/node_modules/glob": {
+            "version": "7.1.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+            "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+            "deprecated": "Glob versions prior to v9 are no longer supported",
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/swagger-parser": {
+            "version": "10.0.3",
+            "resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-10.0.3.tgz",
+            "integrity": "sha512-nF7oMeL4KypldrQhac8RyHerJeGPD1p2xDh900GPvc+Nk7nWP6jX2FcC7WmkinMoAmoO774+AFXcWsW8gMWEIg==",
+            "dependencies": {
+                "@apidevtools/swagger-parser": "10.0.3"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/swagger-ui-dist": {
             "version": "5.31.0",
             "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.31.0.tgz",
@@ -2322,6 +2494,14 @@
                 "node": ">= 0.4.0"
             }
         },
+        "node_modules/validator": {
+            "version": "13.15.26",
+            "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.26.tgz",
+            "integrity": "sha512-spH26xU080ydGggxRyR1Yhcbgx+j3y5jbNXk/8L+iRvdIEQ4uTRH2Sgf2dokud6Q4oAtsbNvJ1Ft+9xmm6IZcA==",
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
         "node_modules/vary": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -2336,6 +2516,42 @@
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
             "license": "ISC"
+        },
+        "node_modules/yaml": {
+            "version": "2.0.0-1",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.0-1.tgz",
+            "integrity": "sha512-W7h5dEhywMKenDJh2iX/LABkbFnBxasD27oyXWDS/feDsxiw0dD5ncXdYXgkvAsXIY2MpW/ZKkr9IU30DBdMNQ==",
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/z-schema": {
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.5.tgz",
+            "integrity": "sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==",
+            "dependencies": {
+                "lodash.get": "^4.4.2",
+                "lodash.isequal": "^4.5.0",
+                "validator": "^13.7.0"
+            },
+            "bin": {
+                "z-schema": "bin/z-schema"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            },
+            "optionalDependencies": {
+                "commander": "^9.4.1"
+            }
+        },
+        "node_modules/z-schema/node_modules/commander": {
+            "version": "9.5.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+            "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+            "optional": true,
+            "engines": {
+                "node": "^12.20.0 || >=14"
+            }
         }
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -554,7 +554,6 @@
             "version": "2.8.5",
             "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
             "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
-            "license": "MIT",
             "dependencies": {
                 "object-assign": "^4",
                 "vary": "^1"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
         "passport-local": "^1.0.0",
         "prisma": "^6.18.0",
         "swagger-autogen": "^2.23.7",
+        "swagger-jsdoc": "^6.2.8",
         "swagger-ui-express": "^5.0.1"
     },
     "devDependencies": {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -166,6 +166,10 @@ model UserCategory {
   userId       String   @map("user_id") @db.Char(36)
   categoryName String   @map("category_name") @db.VarChar(50)
   displayOrder Int      @map("display_order")
+  // PM02 - 기본 아이콘 선택 값
+  iconKey      String?  @map("icon_key") @db.VarChar(50)
+  //PM02 - 사용자 업로드 아이콘 URL
+  iconUrl      String?  @map("icon_url") @db.VarChar(500)
   createdAt    DateTime @default(now()) @map("created_at")
   updatedAt    DateTime @updatedAt @map("updated_at")
 

--- a/src/app.js
+++ b/src/app.js
@@ -1,10 +1,11 @@
-import cors from 'cors';
-import dotenv from 'dotenv';
-import express from 'express';
+import cors from "cors";
+import dotenv from "dotenv";
+import express from "express";
+import pmRouter from "./pm/pm.route.js";
 import {
-    AiPredictionTimeoutError,
-    UnauthorizedError
-} from './errors/app.error.js';
+  AiPredictionTimeoutError,
+  UnauthorizedError,
+} from "./errors/app.error.js";
 
 // 환경변수 설정
 dotenv.config();
@@ -16,91 +17,95 @@ const port = process.env.PORT || 3000;
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 app.use(cors());
-app.use(express.static('public'));
+app.use(express.static("public"));
 
 // 2. 응답 헬퍼 함수 등록
 app.use((req, res, next) => {
-    // 성공 응답
-    res.success = (data, message = '요청 성공') => {
-        return res.json({
-            success: true,
-            data,
-            message
-        });
-    };
+  // 성공 응답
+  res.success = (data, message = "요청 성공") => {
+    return res.json({
+      success: true,
+      data,
+      message,
+    });
+  };
 
-    // 실패 응답
-    res.error = ({ code = 'UNKNOWN', message = '오류 발생', detail = null }) => {
-        return res.json({
-            success: false,
-            error: { code, message, detail }
-        });
-    };
+  // 실패 응답
+  res.error = ({ code = "UNKNOWN", message = "오류 발생", detail = null }) => {
+    return res.json({
+      success: false,
+      error: { code, message, detail },
+    });
+  };
 
-    next();
+  next();
 });
+
+// +) 라우터 등록
+console.log("[ROUTE] mounting /api/pm");
+app.use("/api/pm", pmRouter);
 
 // 3. 테스트용 라우트
 
 // 성공 케이스 테스트
-app.get('/', (req, res) => {
-    const sampleData = { project: 'moduwa-server', status: 'Running' };
-    res.success(sampleData, '서버가 정상 작동 중입니다.');
+app.get("/", (req, res) => {
+  const sampleData = { project: "moduwa-server", status: "Running" };
+  res.success(sampleData, "서버가 정상 작동 중입니다.");
 });
 
 // 에러 케이스 테스트 (직접 throw)
-app.get('/error-test', (req, res, next) => {
-    // Service 로직에서 에러가 발생했다고 가정
-    try {
-        throw new AiPredictionTimeoutError('테스트용 AI 타임아웃 발생');
-    } catch (error) {
-        next(error); // 전역 핸들러로 전달
-    }
+app.get("/error-test", (req, res, next) => {
+  // Service 로직에서 에러가 발생했다고 가정
+  try {
+    throw new AiPredictionTimeoutError("테스트용 AI 타임아웃 발생");
+  } catch (error) {
+    next(error); // 전역 핸들러로 전달
+  }
 });
 
 // 인증 에러 테스트
-app.get('/auth-test', (req, res, next) => {
-    try {
-        throw new UnauthorizedError();
-    } catch (error) {
-        next(error);
-    }
+app.get("/auth-test", (req, res, next) => {
+  try {
+    throw new UnauthorizedError();
+  } catch (error) {
+    next(error);
+  }
 });
 
 // 4. 404 Not Found 핸들러
 app.use((req, res, next) => {
-    res.status(404).error({
-        code: 'NOT_FOUND',
-        message: '요청하신 API 경로를 찾을 수 없습니다.'
-    });
+  res.status(404).error({
+    code: "NOT_FOUND",
+    message: "요청하신 API 경로를 찾을 수 없습니다.",
+  });
 });
 
 // 5. 전역 에러 핸들러 (반드시 최하단에 위치)
 app.use((err, req, res, next) => {
-    // 이미 응답 전송된 경우
-    if (res.headersSent) {
-        return next(err);
-    }
+  // 이미 응답 전송된 경우
+  if (res.headersSent) {
+    return next(err);
+  }
 
-    // 운영 에러 (예측 가능한 에러)
-    if (err.isOperational) {
-        return res.status(err.statusCode).error({
-            code: err.code,
-            message: err.message,
-            detail: err.detail || null
-        });
-    }
-
-    // 프로그래밍 에러 (예측 불가능한 시스템 에러)
-    console.error('ERROR:', err); // 서버 로그용
-    return res.status(500).error({
-        code: 'SERVER_ERROR',
-        message: '서버 내부 오류가 발생했습니다',
-        detail: process.env.NODE_ENV === 'development' ? err.message : null // 개발 환경에서만 상세 출력
+  // 운영 에러 (예측 가능한 에러)
+  if (err.isOperational) {
+    return res.status(err.statusCode).error({
+      code: err.code,
+      message: err.message,
+      detail: err.detail || null,
     });
+  }
+
+  // 프로그래밍 에러 (예측 불가능한 시스템 에러)
+  console.error("ERROR:", err); // 서버 로그용
+  return res.status(500).error({
+    code: "SERVER_ERROR",
+    message: "서버 내부 오류가 발생했습니다",
+    detail: process.env.NODE_ENV === "development" ? err.message : null, // 개발 환경에서만 상세 출력
+  });
 });
 
 // 서버 실행
 app.listen(port, () => {
-    console.log(`Example app listening on port ${port}`);
+  console.log(`Example app listening on port ${port}`);
 });

--- a/src/app.js
+++ b/src/app.js
@@ -6,6 +6,8 @@ import {
   AiPredictionTimeoutError,
   UnauthorizedError,
 } from "./errors/app.error.js";
+import swaggerUi from "swagger-ui-express";
+import { swaggerSpec } from "./swagger/swagger.js";
 
 // 환경변수 설정
 dotenv.config();
@@ -42,6 +44,7 @@ app.use((req, res, next) => {
 });
 
 // +) 라우터 등록
+app.use("/api-docs", swaggerUi.serve, swaggerUi.setup(swaggerSpec));
 console.log("[ROUTE] mounting /api/pm");
 app.use("/api/pm", pmRouter);
 

--- a/src/middlewares/auth.middleware.js
+++ b/src/middlewares/auth.middleware.js
@@ -1,0 +1,29 @@
+import { BaseError } from "../errors/app.error.js";
+
+const authMiddleware = (req, res, next) => {
+  try {
+    const authHeader = req.headers.authorization;
+
+    if (!authHeader) {
+      throw new BaseError("인증이 필요합니다", 401, "AUTH001");
+    }
+
+    const [type, token] = authHeader.split(" ");
+
+    if (type !== "Bearer" || !token) {
+      throw new BaseError(
+        "Authorization 형식이 올바르지 않습니다",
+        401,
+        "AUTH001"
+      );
+    }
+
+    // token을 userId로 간주
+    req.user = { userId: token };
+    return next();
+  } catch (err) {
+    return next(err);
+  }
+};
+
+export default authMiddleware;

--- a/src/pm/pm.controller.js
+++ b/src/pm/pm.controller.js
@@ -1,0 +1,79 @@
+import { BaseError } from "../errors/app.error.js";
+import {
+  createPm02Category,
+  updatePm02Category,
+  deletePm02Category,
+} from "./pm.service.js";
+import {
+  toPm02CategoryResponse,
+  toPm02CategoryDeleteResponse,
+} from "./pm.dto.js";
+import { validateCategoryName, validateIconFields } from "./pm.validator.js";
+
+export const createCategory = async (req, res, next) => {
+  try {
+    const userId = req.user?.userId;
+    if (!userId) throw new BaseError("인증이 필요합니다", 401, "AUTH001");
+
+    const { categoryName, iconKey, iconUrl } = req.body;
+
+    validateCategoryName(categoryName, { required: true });
+    validateIconFields({ iconKey, iconUrl });
+
+    const created = await createPm02Category({
+      userId,
+      categoryName,
+      iconKey,
+      iconUrl,
+    });
+
+    return res
+      .status(201)
+      .success(toPm02CategoryResponse(created), "카테고리 생성 성공");
+  } catch (err) {
+    return next(err);
+  }
+};
+
+export const patchCategory = async (req, res, next) => {
+  try {
+    const userId = req.user?.userId;
+    if (!userId) throw new BaseError("인증이 필요합니다", 401, "AUTH001");
+
+    const { id } = req.params;
+    const { categoryName, iconKey, iconUrl } = req.body;
+
+    validateCategoryName(categoryName, { required: false });
+    validateIconFields({ iconKey, iconUrl });
+
+    const updated = await updatePm02Category({
+      userId,
+      id,
+      ...(categoryName !== undefined ? { categoryName } : {}),
+      ...(iconKey !== undefined ? { iconKey } : {}),
+      ...(iconUrl !== undefined ? { iconUrl } : {}),
+    });
+
+    return res
+      .status(200)
+      .success(toPm02CategoryResponse(updated), "카테고리 수정 성공");
+  } catch (err) {
+    return next(err);
+  }
+};
+
+export const removeCategory = async (req, res, next) => {
+  try {
+    const userId = req.user?.userId;
+    if (!userId) throw new BaseError("인증이 필요합니다", 401, "AUTH001");
+
+    const { id } = req.params;
+    await deletePm02Category({ userId, id });
+
+    return res
+      .status(200)
+      .success(toPm02CategoryDeleteResponse(id), "카테고리 삭제 성공");
+  } catch (err) {
+    return next(err);
+  }
+};

--- a/src/pm/pm.dto.js
+++ b/src/pm/pm.dto.js
@@ -1,0 +1,11 @@
+export const toPm02CategoryResponse = (userCategory) => ({
+  id: userCategory.id,
+  name: userCategory.categoryName,
+  iconKey: userCategory.iconKey,
+  iconUrl: userCategory.iconUrl,
+  displayOrder: userCategory.displayOrder,
+});
+
+export const toPm02CategoryDeleteResponse = (categoryId) => ({
+  id: categoryId,
+});

--- a/src/pm/pm.repository.js
+++ b/src/pm/pm.repository.js
@@ -1,0 +1,43 @@
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+export const createUserCategory = async ({
+  userId,
+  categoryName,
+  displayOrder,
+}) => {
+  return prisma.userCategory.create({
+    data: {
+      userId,
+      categoryName,
+      displayOrder,
+    },
+  });
+};
+
+export const findUserCategoryById = async ({ userId, id }) => {
+  return prisma.userCategory.findFirst({
+    where: { id, userId },
+  });
+};
+
+export const updateUserCategory = async ({
+  id,
+  categoryName,
+  displayOrder,
+}) => {
+  return prisma.userCategory.update({
+    where: { id },
+    data: {
+      ...(categoryName !== undefined ? { categoryName } : {}),
+      ...(displayOrder !== undefined ? { displayOrder } : {}),
+    },
+  });
+};
+
+export const deleteUserCategory = async ({ id }) => {
+  return prisma.userCategory.delete({
+    where: { id },
+  });
+};

--- a/src/pm/pm.route.js
+++ b/src/pm/pm.route.js
@@ -1,0 +1,17 @@
+import express from "express";
+import authMiddleware from "../middlewares/auth.middleware.js";
+
+import {
+  createCategory,
+  patchCategory,
+  removeCategory,
+} from "./pm.controller.js";
+
+const router = express.Router();
+
+// PM-02
+router.post("/categories", authMiddleware, createCategory);
+router.patch("/categories/:id", authMiddleware, patchCategory);
+router.delete("/categories/:id", authMiddleware, removeCategory);
+
+export default router;

--- a/src/pm/pm.service.js
+++ b/src/pm/pm.service.js
@@ -1,0 +1,77 @@
+import { PrismaClient } from "@prisma/client";
+import {
+  createUserCategory,
+  findUserCategoryById,
+  updateUserCategory,
+  deleteUserCategory,
+} from "./pm.repository.js";
+
+const prisma = new PrismaClient();
+
+import { BaseError } from "../errors/app.error.js";
+
+export const createPm02Category = async ({ userId, categoryName }) => {
+  const maxResult = await prisma.userCategory.aggregate({
+    where: { userId },
+    _max: { displayOrder: true },
+  });
+  const nextOrder = (maxResult._max.displayOrder ?? -1) + 1;
+
+  try {
+    return await createUserCategory({
+      userId,
+      categoryName,
+      displayOrder: nextOrder,
+    });
+  } catch (err) {
+    if (err.code === "P2002") {
+      throw new BaseError(
+        "이미 존재하는 카테고리명입니다",
+        409,
+        "PM_DUPLICATE_CATEGORY"
+      );
+    }
+    throw err;
+  }
+};
+
+export const updatePm02Category = async ({ userId, id, categoryName }) => {
+  const existing = await findUserCategoryById({ userId, id });
+  if (!existing) {
+    throw new BaseError(
+      "카테고리를 찾을 수 없습니다",
+      404,
+      "PM_CATEGORY_NOT_FOUND"
+    );
+  }
+
+  try {
+    return await updateUserCategory({
+      id,
+      ...(categoryName !== undefined ? { categoryName } : {}),
+    });
+  } catch (err) {
+    if (err.code === "P2002") {
+      throw new BaseError(
+        "이미 존재하는 카테고리명입니다",
+        409,
+        "PM_DUPLICATE_CATEGORY"
+      );
+    }
+    throw err;
+  }
+};
+
+export const deletePm02Category = async ({ userId, id }) => {
+  const existing = await findUserCategoryById({ userId, id });
+  if (!existing) {
+    throw new BaseError(
+      "카테고리를 찾을 수 없습니다",
+      404,
+      "PM_CATEGORY_NOT_FOUND"
+    );
+  }
+
+  await deleteUserCategory({ id });
+  return true;
+};

--- a/src/pm/pm.validator.js
+++ b/src/pm/pm.validator.js
@@ -1,0 +1,36 @@
+import { BaseError } from "../errors/app.error.js";
+
+// categoryName 검증
+export const validateCategoryName = (categoryName, { required }) => {
+  if (required && (categoryName === undefined || categoryName === null)) {
+    throw new BaseError("categoryName은 필수입니다", 400, "PM400");
+  }
+
+  // PATCH에서 categoryName을 안 보냈으면 검증 스킵
+  if (categoryName === undefined || categoryName === null) return;
+
+  if (typeof categoryName !== "string") {
+    throw new BaseError("categoryName은 문자열이어야 합니다", 400, "PM400");
+  }
+
+  const trimmed = categoryName.trim();
+  if (trimmed.length < 1 || trimmed.length > 50) {
+    throw new BaseError("categoryName은 1~50자여야 합니다", 400, "PM400");
+  }
+};
+
+// iconKey/iconUrl 검증 : 둘 다 동시에 값이 있으면 안 됨
+export const validateIconFields = ({ iconKey, iconUrl }) => {
+  const hasIconKey =
+    iconKey !== undefined && iconKey !== null && String(iconKey).trim() !== "";
+  const hasIconUrl =
+    iconUrl !== undefined && iconUrl !== null && String(iconUrl).trim() !== "";
+
+  if (hasIconKey && hasIconUrl) {
+    throw new BaseError(
+      "iconKey와 iconUrl은 동시에 설정할 수 없습니다",
+      400,
+      "PM400"
+    );
+  }
+};

--- a/src/swagger/swagger.js
+++ b/src/swagger/swagger.js
@@ -1,0 +1,125 @@
+import swaggerJSDoc from "swagger-jsdoc";
+
+const swaggerDefinition = {
+  openapi: "3.0.0",
+  info: {
+    title: "MODUWA API",
+    version: "1.0.0",
+    description: "모두와 백엔드 API 문서",
+  },
+  servers: [{ url: "http://localhost:3000", description: "local" }],
+
+  tags: [
+    { name: "Auth", description: "인증/인가 (JWT, OAuth2)" },
+    { name: "AI", description: "AI 관련 API" },
+    { name: "User", description: "유저 관련 API" },
+    { name: "PM02", description: "낱말 카테고리 (생성/수정/삭제)" },
+    { name: "PM03", description: "낱말-카테고리 순서 변경" },
+    { name: "PM05", description: "루틴 문장 설정" },
+    { name: "PM06", description: "그리드 커스터마이징" },
+  ],
+
+  components: {
+    securitySchemes: {
+      // JWT Bearer
+      bearerAuth: {
+        type: "http",
+        scheme: "bearer",
+        bearerFormat: "JWT",
+      },
+    },
+
+    schemas: {
+      // 공통 성공 응답
+      SuccessResponse: {
+        type: "object",
+        properties: {
+          success: { type: "boolean", example: true },
+          data: { type: "object", nullable: true, example: { any: "thing" } },
+          message: { type: "string", example: "요청 성공" },
+        },
+        required: ["success", "data", "message"],
+      },
+
+      // 공통 실패 응답
+      ErrorResponse: {
+        type: "object",
+        properties: {
+          success: { type: "boolean", example: false },
+          error: {
+            type: "object",
+            properties: {
+              code: { type: "string", example: "AI001" },
+              message: { type: "string", example: "AI 응답 시간 초과" },
+              detail: {
+                type: "string",
+                nullable: true,
+                example: "서버 부하로 인한 지연",
+              },
+            },
+            required: ["code", "message"],
+          },
+        },
+        required: ["success", "error"],
+      },
+    },
+
+    responses: {
+      Unauthorized: {
+        description: "인증 필요",
+        content: {
+          "application/json": {
+            schema: { $ref: "#/components/schemas/ErrorResponse" },
+            example: {
+              success: false,
+              error: {
+                code: "AUTH001",
+                message: "인증이 필요합니다",
+                detail: null,
+              },
+            },
+          },
+        },
+      },
+      Forbidden: {
+        description: "권한 없음",
+        content: {
+          "application/json": {
+            schema: { $ref: "#/components/schemas/ErrorResponse" },
+            example: {
+              success: false,
+              error: {
+                code: "AUTH002",
+                message: "권한이 없습니다",
+                detail: null,
+              },
+            },
+          },
+        },
+      },
+      AiTimeout: {
+        description: "AI 응답 시간 초과",
+        content: {
+          "application/json": {
+            schema: { $ref: "#/components/schemas/ErrorResponse" },
+            example: {
+              success: false,
+              error: {
+                code: "AI001",
+                message: "AI 응답 시간 초과",
+                detail: "서버 부하로 인한 지연",
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+const options = {
+  swaggerDefinition,
+  apis: ["./src/**/*.js"],
+};
+
+export const swaggerSpec = swaggerJSDoc(options);


### PR DESCRIPTION
## 📌 PR 요약
- Swagger 초기 세팅

## ⚡ 주요 변경 사항
- Swagger UI 기본 설정 추가 (`/api-docs`)
- 공통 성공/실패 응답 스키마 정의
- JWT / OAuth2 인증 스키마 설정

## ✅ 사용 방법
- 로컬 실행 후 `http://localhost:3000/api-docs` 접속
- 각 API는 라우터 파일 상단에 Swagger 주석 추가 방식으로 확장 가능

## 📎 관련 이슈
- Closed #9
