### PR TITLE
[Feat] 그리드 커스터마이징 조회/수정 API 구현

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -16,6 +16,7 @@ import aiRouter from "./ai-prediction/routes/ai.prediction.route.js";
 import historyRouter from "./history/history.route.js";
 import authRoutes from "./auth/routes/auth.routes.js";
 import routineRouter from "./routine/routine.route.js";
+import settingsRouter from "./settings/settings.route.js";
 
 // 유틸리티
 import responseHelper from "./utils/response.util.js";
@@ -73,6 +74,9 @@ app.use("/api/categories", categoryRouter);
 
 // 루틴 문장 API
 app.use("/api/routines", routineRouter);
+
+// 그리드 커스터마이징 API
+app.use("/api/settings", settingsRouter);
 
 // AI 예측 API
 app.use("/api/ai", aiRouter);

--- a/src/settings/settings.controller.js
+++ b/src/settings/settings.controller.js
@@ -1,10 +1,11 @@
 import { UnauthorizedError } from "../errors/app.error.js";
 import { getGridColumns } from "./settings.service.js";
+import { validateUpdateGridBody } from "./settings.validator.js";
+import { updateGridColumns } from "./settings.service.js";
 
-// ✅ PM-06 GET /api/settings/grid
+// GET
 export const getGridSettings = async (req, res, next) => {
   try {
-    // 프로젝트에서 userId가 여러 형태로 들어오는 케이스 대응
     const userId = req.user?.userId ?? req.userId ?? req.user?.id;
 
     if (!userId) {
@@ -21,6 +22,36 @@ export const getGridSettings = async (req, res, next) => {
       success: true,
       data: { gridColumns },
       message: "그리드 설정 조회 성공",
+    });
+  } catch (err) {
+    next(err);
+  }
+};
+
+// PATCH
+export const patchGridSettings = async (req, res, next) => {
+  try {
+    const userId = req.user?.userId ?? req.userId ?? req.user?.id;
+
+    if (!userId) {
+      throw new UnauthorizedError("인증 정보가 없습니다.");
+    }
+
+    const { gridColumns } = validateUpdateGridBody(req.body);
+
+    const settings = await updateGridColumns({ userId, gridColumns });
+
+    if (typeof res.success === "function") {
+      return res.success(
+        { gridColumns: settings.gridColumns },
+        "그리드 설정 변경 성공",
+      );
+    }
+
+    return res.status(200).json({
+      success: true,
+      message: "그리드 설정 변경 성공",
+      data: { gridColumns: settings.gridColumns },
     });
   } catch (err) {
     next(err);

--- a/src/settings/settings.controller.js
+++ b/src/settings/settings.controller.js
@@ -1,0 +1,28 @@
+import { UnauthorizedError } from "../errors/app.error.js";
+import { getGridColumns } from "./settings.service.js";
+
+// ✅ PM-06 GET /api/settings/grid
+export const getGridSettings = async (req, res, next) => {
+  try {
+    // 프로젝트에서 userId가 여러 형태로 들어오는 케이스 대응
+    const userId = req.user?.userId ?? req.userId ?? req.user?.id;
+
+    if (!userId) {
+      throw new UnauthorizedError("인증 정보가 없습니다.");
+    }
+
+    const gridColumns = await getGridColumns({ userId });
+
+    if (typeof res.success === "function") {
+      return res.success({ gridColumns }, "그리드 설정 조회 성공");
+    }
+
+    return res.status(200).json({
+      success: true,
+      data: { gridColumns },
+      message: "그리드 설정 조회 성공",
+    });
+  } catch (err) {
+    next(err);
+  }
+};

--- a/src/settings/settings.repository.js
+++ b/src/settings/settings.repository.js
@@ -1,25 +1,24 @@
 import prisma from "../config/prisma.config.js";
 
-/**
- * ✅ UserSettings가 없으면 생성해서 반환
- * - gridColumns 기본값: 7
- *
- * ⚠️ Prisma model명이 `UserSettings`라면 client는 `prisma.userSettings`가 됩니다.
- * (지금 routine에서 RoutineMessage 썼던 것처럼, model 이름 기준으로 camelCase)
- */
 export const getOrCreateUserSettings = async ({ userId }) => {
-  // 1) 먼저 찾고
   const existing = await prisma.userSettings.findUnique({
     where: { userId },
   });
 
   if (existing) return existing;
 
-  // 2) 없으면 생성
   return prisma.userSettings.create({
     data: {
       userId,
       gridColumns: 7,
     },
+  });
+};
+
+export const upsertUserGridColumns = async ({ userId, gridColumns }) => {
+  return prisma.userSettings.upsert({
+    where: { userId },
+    update: { gridColumns },
+    create: { userId, gridColumns },
   });
 };

--- a/src/settings/settings.repository.js
+++ b/src/settings/settings.repository.js
@@ -1,0 +1,25 @@
+import prisma from "../config/prisma.config.js";
+
+/**
+ * ✅ UserSettings가 없으면 생성해서 반환
+ * - gridColumns 기본값: 7
+ *
+ * ⚠️ Prisma model명이 `UserSettings`라면 client는 `prisma.userSettings`가 됩니다.
+ * (지금 routine에서 RoutineMessage 썼던 것처럼, model 이름 기준으로 camelCase)
+ */
+export const getOrCreateUserSettings = async ({ userId }) => {
+  // 1) 먼저 찾고
+  const existing = await prisma.userSettings.findUnique({
+    where: { userId },
+  });
+
+  if (existing) return existing;
+
+  // 2) 없으면 생성
+  return prisma.userSettings.create({
+    data: {
+      userId,
+      gridColumns: 7,
+    },
+  });
+};

--- a/src/settings/settings.route.js
+++ b/src/settings/settings.route.js
@@ -1,0 +1,9 @@
+import express from "express";
+import { getGridSettings } from "./settings.controller.js";
+import authMiddleware from "../middlewares/auth.middleware.js";
+
+const router = express.Router();
+
+router.get("/grid", authMiddleware, getGridSettings);
+
+export default router;

--- a/src/settings/settings.route.js
+++ b/src/settings/settings.route.js
@@ -1,9 +1,11 @@
 import express from "express";
 import { getGridSettings } from "./settings.controller.js";
+import { patchGridSettings } from "./settings.controller.js";
 import authMiddleware from "../middlewares/auth.middleware.js";
 
 const router = express.Router();
 
 router.get("/grid", authMiddleware, getGridSettings);
+router.patch("/grid", authMiddleware, patchGridSettings);
 
 export default router;

--- a/src/settings/settings.service.js
+++ b/src/settings/settings.service.js
@@ -12,3 +12,20 @@ export const getGridColumns = async ({ userId }) => {
 
   return settings.gridColumns ?? 7;
 };
+
+export const updateGridColumns = async ({ userId, gridColumns }) => {
+  // MOCK
+  //   if (
+  //     process.env.NODE_ENV === "development" &&
+  //     process.env.MOCK_DB === "true"
+  //   ) {
+  //     return {
+  //       id: "mock-settings",
+  //       userId,
+  //       gridColumns,
+  //       updatedAt: new Date().toISOString(),
+  //     };
+  //   }
+  const settings = await upsertUserGridColumns({ userId, gridColumns });
+  return settings;
+};

--- a/src/settings/settings.service.js
+++ b/src/settings/settings.service.js
@@ -1,13 +1,13 @@
 import { getOrCreateUserSettings } from "./settings.repository.js";
 
 export const getGridColumns = async ({ userId }) => {
-  // ✅ [추가] 로컬 mock 모드면 DB 건드리지 말고 기본값 반환
-  if (
-    process.env.NODE_ENV === "development" &&
-    process.env.MOCK_DB === "true"
-  ) {
-    return 7;
-  }
+  // MOCK
+  //   if (
+  //     process.env.NODE_ENV === "development" &&
+  //     process.env.MOCK_DB === "true"
+  //   ) {
+  //     return 7;
+  //   }
   const settings = await getOrCreateUserSettings({ userId });
 
   return settings.gridColumns ?? 7;

--- a/src/settings/settings.service.js
+++ b/src/settings/settings.service.js
@@ -1,0 +1,14 @@
+import { getOrCreateUserSettings } from "./settings.repository.js";
+
+export const getGridColumns = async ({ userId }) => {
+  // ✅ [추가] 로컬 mock 모드면 DB 건드리지 말고 기본값 반환
+  if (
+    process.env.NODE_ENV === "development" &&
+    process.env.MOCK_DB === "true"
+  ) {
+    return 7;
+  }
+  const settings = await getOrCreateUserSettings({ userId });
+
+  return settings.gridColumns ?? 7;
+};

--- a/src/settings/settings.validator.js
+++ b/src/settings/settings.validator.js
@@ -1,0 +1,20 @@
+import { BaseError } from "../errors/app.error.js";
+
+export const validateUpdateGridBody = (body) => {
+  const { gridColumns } = body ?? {};
+
+  if (gridColumns === undefined || gridColumns === null) {
+    throw new BaseError("gridColumns는 필수입니다.", 400);
+  }
+
+  if (!Number.isInteger(gridColumns)) {
+    throw new BaseError("gridColumns는 정수여야 합니다.", 400);
+  }
+
+  const allowed = [3, 4, 7];
+  if (!allowed.includes(gridColumns)) {
+    throw new BaseError("gridColumns는 3, 4, 7 중 하나여야 합니다.", 400);
+  }
+
+  return { gridColumns };
+};


### PR DESCRIPTION
## 📌 PR 요약
- PM-06 말하기 화면 그리드 커스터마이징 API 구현
  - 한 줄에 표시할 카드 개수(3 / 4 / 7열) 조회 및 수정 기능 추가

## ⚡ 주요 변경 사항
- GET /api/settings/grid
  - 사용자 말하기 화면 그리드 설정 조회
  - 설정이 없는 경우 기본값(7열) 반환
- PATCH /api/settings/grid
  - 그리드 열 수 변경 API 구현
  - gridColumns 값은 3 / 4 / 7만 허용

## ✅ 테스트 내용
- Postman을 통한 API 단위 테스트 완료

## 📎 관련 이슈
- Closed #22 
