### PR TITLE
[Fix] username에 ubuntu 직접 지정

### DIFF
--- a/.github/workflows/cd-deploy.yml
+++ b/.github/workflows/cd-deploy.yml
@@ -83,7 +83,7 @@ jobs:
         uses: appleboy/ssh-action@v1.0.3
         with:
           host: ${{ secrets.EC2_HOST }}
-          username: ${{ secrets.EC2_USER }}
+          username: ubuntu
           key: ${{ secrets.EC2_SSH_KEY }}
           port: 22
           script: |


### PR DESCRIPTION
## 📌 PR 요약
- CI/CD 파이프라인에서 EC2_USER secrets 없이 username에 ubuntu를 직접 지정하도록 수정

## ⚡ 주요 변경 사항
- `.github/workflows/cd-deploy.yml`에서 `username: ${{ secrets.EC2_USER }}` → `username: ubuntu`로 변경

## ✅ 테스트 내용
- develop 브랜치로 PR 생성 시 CI 정상 동작 확인
- 머지 후 CD(EC2 자동 배포) 정상 동작 여부 확인 예정

## 📎 관련 이슈

## 📝 기타 참고사항
