### PR TITLE
[Fix] Words API 인증 강화 및 버그 수정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,9 +86,6 @@ services:
       KAKAO_CLIENT_ID: ${KAKAO_CLIENT_ID}
       KAKAO_REDIRECT_URI: ${KAKAO_REDIRECT_URI}
       FASTAPI_URL: http://fastapi:8000
-      JWT_SECRET: your-super-secret-jwt-key-change-this-in-production
-      JWT_ACCESS_EXPIRES_IN: 1h
-      JWT_REFRESH_EXPIRES_IN: 14d
       NODE_ENV: development
       PORT: 3000
     ports:

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -126,10 +126,11 @@ async function main() {
       data: {
         userId: user.id,
         wordId: createdWords[idx].id,
+        categoryId: createdWords[idx].categoryId,
         isFavorite: true,
         isDeleted: false,
-        partOfSpeech: createdWords[idx].partOfSpeech, // 이전 에러 해결
-        displayOrder: i + 1 // 새로 발생한 에러 해결: 순차적으로 1, 2, 3 부여
+        partOfSpeech: createdWords[idx].partOfSpeech,
+        displayOrder: i + 1
       }
     });
   }

--- a/src/words/repositories/words.repository.js
+++ b/src/words/repositories/words.repository.js
@@ -257,7 +257,7 @@ export class WordsRepository {
     const data = {};
     if (customWord !== undefined) data.customWord = customWord;
     if (customImageUrl !== undefined) data.customImageUrl = customImageUrl;
-    if (categoryId !== undefined) data.categoryId = categoryId;
+    if (categoryId !== undefined && categoryId !== null) data.categoryId = categoryId;
 
     return await prisma.userWord.update({
       where: { id: userWordId },

--- a/src/words/routes/words.route.js
+++ b/src/words/routes/words.route.js
@@ -1,7 +1,7 @@
 import express from 'express';
 import wordsController from '../controllers/words.controller.js';
 import wordsValidator from '../middlewares/words.validator.js';
-import { authenticate, optionalAuthenticate } from '../../auth/middlewares/auth.middleware.js';
+import { authenticate, optionalAuthenticate, socialOnly } from '../../auth/middlewares/auth.middleware.js';
 
 const router = express.Router();
 
@@ -15,36 +15,36 @@ router.get('/', optionalAuthenticate, wordsController.getWords.bind(wordsControl
 /**
  * POST /api/words - 개인 낱말 카드 추가
  * Body: categoryId, word, imageUrl
- * 인증: 필수
+ * 인증: 필수 (SOCIAL 계정만)
  */
-router.post('/', authenticate, wordsController.createWord.bind(wordsController));
+router.post('/', authenticate, socialOnly, wordsController.createWord.bind(wordsController));
 
 /**
  * PATCH /api/words/reorder - 낱말 카드 순서 변경
  * Body: categoryId, orderedCardIds
- * 인증: 필수
+ * 인증: 필수 (SOCIAL 계정만)
  * Note: 이 라우트는 /:cardId/favorite, /:cardId 보다 위에 있어야 함
  */
-router.patch('/reorder', authenticate, wordsValidator.validateReorderWordsBody, wordsController.reorderWords.bind(wordsController));
+router.patch('/reorder', authenticate, socialOnly, wordsValidator.validateReorderWordsBody, wordsController.reorderWords.bind(wordsController));
 
 /**
  * PATCH /api/words/:cardId/favorite - 낱말 카드 즐겨찾기 변경
  * Body: isFavorite
- * 인증: 필수
+ * 인증: 필수 (SOCIAL 계정만)
  */
-router.patch('/:cardId/favorite', authenticate, wordsController.updateFavorite.bind(wordsController));
+router.patch('/:cardId/favorite', authenticate, socialOnly, wordsController.updateFavorite.bind(wordsController));
 
 /**
  * PATCH /api/words/:cardId - 낱말 카드 수정
  * Body: word, imageUrl
- * 인증: 필수
+ * 인증: 필수 (SOCIAL 계정만)
  */
-router.patch('/:cardId', authenticate, wordsController.updateWord.bind(wordsController));
+router.patch('/:cardId', authenticate, socialOnly, wordsController.updateWord.bind(wordsController));
 
 /**
  * DELETE /api/words/:cardId - 낱말 카드 삭제
- * 인증: 필수
+ * 인증: 필수 (SOCIAL 계정만)
  */
-router.delete('/:cardId', authenticate, wordsController.deleteWord.bind(wordsController));
+router.delete('/:cardId', authenticate, socialOnly, wordsController.deleteWord.bind(wordsController));
 
 export default router;

--- a/src/words/services/words.service.js
+++ b/src/words/services/words.service.js
@@ -46,24 +46,28 @@ export class WordsService {
       categoryName = category?.categoryName || null;
     }
 
-    // 1. UserWord 조회 (개인화된 낱말) - includeDeleted=true로 삭제된 것도 포함
-    const userWords = await wordsRepository.findUserWords(userId, categoryId, onlyFavorite, true);
-    
-    // UserWord를 cardId 맵으로 저장 (wordId 기준)
+    // userId가 있을 때만 사용자 낱말 조회
+    let userWords = [];
     const userWordMap = new Map();
-    userWords.forEach(uw => {
-      if (uw.wordId) {
-        userWordMap.set(uw.wordId, uw);
-      }
-    });
-
-    // isDeleted=true인 Word.id를 수집 (기본 낱말 필터링용)
     const deletedWordIds = new Set();
-    userWords.forEach(uw => {
-      if (uw.wordId && uw.isDeleted) {
-        deletedWordIds.add(uw.wordId);
-      }
-    });
+    if (userId) {
+      // 1. UserWord 조회 (개인화된 낱말) - includeDeleted=true로 삭제된 것도 포함
+      userWords = await wordsRepository.findUserWords(userId, categoryId, onlyFavorite, true);
+      
+      // UserWord를 cardId 맵으로 저장 (wordId 기준)
+      userWords.forEach(uw => {
+        if (uw.wordId) {
+          userWordMap.set(uw.wordId, uw);
+        }
+      });
+
+      // isDeleted=true인 Word.id를 수집 (기본 낱말 필터링용)
+      userWords.forEach(uw => {
+        if (uw.wordId && uw.isDeleted) {
+          deletedWordIds.add(uw.wordId);
+        }
+      });
+    }
 
     // 2. 기본 낱말(Word) 먼저 조회 (UserWord가 없는 것만)
     if (!onlyFavorite) {
@@ -340,6 +344,7 @@ export class WordsService {
         baseWordIds.push(cardId);
       }
     }
+
 
     // 2. 기본 Word 참조가 있으면 스냅샷 생성 (아직 생성되지 않은 것만)
     if (baseWordIds.length > 0) {


### PR DESCRIPTION
## 📌 PR 요약
- Words API의 인증/인가 로직을 강화하고, 데이터 무결성 관련 버그를 수정했습니다.

## ⚡ 주요 변경 사항
- **인증 강화**: `socialOnly` 미들웨어를 모든 쓰기 엔드포인트에 추가
  - POST /api/words (낱말 추가)
  - PATCH /api/words/reorder (순서 변경)
  - PATCH /api/words/:cardId/favorite (즐겨찾기 변경)
  - PATCH /api/words/:cardId (낱말 수정)
  - DELETE /api/words/:cardId (낱말 삭제)
  
- **데이터 보안 개선**: `getWords()` 메서드에서 비인증 사용자의 UserWord 조회 방지
  - userId가 없을 때 UserWord 쿼리를 건너뛰도록 로직 수정
  - 비인증 사용자는 기본 낱말(Word)만 조회 가능

- **버그 수정**:
  - `updateUserWord()`에서 categoryId를 명시하지 않으면 null로 변경되던 문제 해결
  - UserWord 즐겨찾기 생성 시 categoryId 누락 문제 해결 (seed.js)
  
- **보안 개선**: docker-compose.yml에서 JWT_SECRET 하드코딩 제거 (.env 파일 사용)

## ✅ 테스트 내용
- ✅ **GET /api/words** (비인증) - 기본 낱말만 조회 확인
- ✅ **GET /api/words** (인증) - 기본 + 사용자 낱말 조회 확인
- ✅ **POST /api/words** (GUEST 토큰) - 403 Forbidden 응답 확인
- ✅ **POST /api/words** (SOCIAL 토큰) - 낱말 생성 성공
- ✅ **PATCH /api/words/:cardId** - 수정 시 categoryId 보존 확인
- ✅ **PATCH /api/words/reorder** - 순서 변경 성공 (전체 카드 ID 포함)
- ✅ **DELETE /api/words/:cardId** - 낱말 삭제 성공

## 📎 관련 이슈
- Closed #1

## 📝 기타 참고사항
- JWT_SECRET 환경 변수가 .env 파일에 설정되어 있어야 Docker 환경에서 정상 작동합니다.
- reorder API는 해당 카테고리의 모든 카드 ID를 포함한 배열을 받아야 합니다.
- GUEST 계정은 낱말 조회만 가능하며, 추가/수정/삭제는 SOCIAL 계정만 가능합니다.