### PR TITLE
[hotfix]: modified docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,7 @@ services:
       - ./fastapi-server:/app
     networks:
       - moduwa_network
-    command: uvicorn main:app --host 0.0.0.0 --port 8000 --reload
+    command: uvicorn main:app --host 0.0.0.0 --port 8000
 
   # ==========================================
   # Backend API (Node.js + Express + Prisma)


### PR DESCRIPTION
## 📌 PR 요약
- aws 인스턴스 메모리 사용량 증가(초과) 이슈로 서버가 다운되는 현상 발생
- 도커 파일에서 자동으로 재시작 되는 커맨드 제거

## ⚡ 주요 변경 사항
- `docker-compose.yml`에서 FastAPI  `--reload` 옵션 제거 (CD로 넘겨질 때만 재시작)

## ✅ 테스트 내용
- 

## 📎 관련 이슈
- Closed #

## 📝 기타 참고사항
- 기타 이슈 또는 참고 자료
