### PR TITLE
[Feat] 낱말 조회 시 카테고리 이름 포함하도록 수정

### DIFF
--- a/src/words/dto/words.dto.js
+++ b/src/words/dto/words.dto.js
@@ -115,6 +115,7 @@ export class WordCardResponseDto {
   constructor({
     cardId,
     categoryId,
+    categoryName,
     partOfSpeech,
     word,
     imageUrl,
@@ -124,6 +125,7 @@ export class WordCardResponseDto {
   }) {
     this.cardId = cardId;
     this.categoryId = categoryId;
+    this.categoryName = categoryName;
     this.partOfSpeech = partOfSpeech;
     this.word = word;
     this.imageUrl = imageUrl;

--- a/src/words/services/words.service.js
+++ b/src/words/services/words.service.js
@@ -80,6 +80,7 @@ export class WordsService {
           wordCards.push(new WordCardResponseDto({
             cardId: word.id, // Word.id
             categoryId: word.categoryId,
+            categoryName: word.category?.categoryName,
             partOfSpeech: word.partOfSpeech,
             word: word.word,
             imageUrl: word.imageUrl,
@@ -104,10 +105,12 @@ export class WordsService {
       
       // categoryId 결정: userCategoryId 우선, 없으면 categoryId
       const cardCategoryId = uw.userCategoryId || uw.categoryId;
+      const cardCategoryName = uw.userCategory?.categoryName || uw.category?.categoryName;
 
       wordCards.push(new WordCardResponseDto({
         cardId: uw.id, // UserWord.id
         categoryId: cardCategoryId,
+        categoryName: cardCategoryName,
         partOfSpeech: uw.partOfSpeech,
         word: displayWord,
         imageUrl: displayImageUrl,
@@ -161,15 +164,19 @@ export class WordsService {
       partOfSpeech
     );
 
+    // 4. 생성된 UserWord 다시 조회 (category 정보 포함)
+    const userWordWithCategory = await wordsRepository.findUserWordById(createdUserWord.id);
+
     return new WordCardResponseDto({
-      cardId: createdUserWord.id,
-      categoryId: createdUserWord.userCategoryId || createdUserWord.categoryId,
-      partOfSpeech: createdUserWord.partOfSpeech,
-      word: createdUserWord.customWord,
-      imageUrl: createdUserWord.customImageUrl,
+      cardId: userWordWithCategory.id,
+      categoryId: userWordWithCategory.userCategoryId || userWordWithCategory.categoryId,
+      categoryName: userWordWithCategory.userCategory?.categoryName || userWordWithCategory.category?.categoryName,
+      partOfSpeech: userWordWithCategory.partOfSpeech,
+      word: userWordWithCategory.customWord,
+      imageUrl: userWordWithCategory.customImageUrl,
       isDefault: false,
-      isFavorite: createdUserWord.isFavorite,
-      displayOrder: createdUserWord.displayOrder
+      isFavorite: userWordWithCategory.isFavorite,
+      displayOrder: userWordWithCategory.displayOrder
     });
   }
 
@@ -250,6 +257,7 @@ export class WordsService {
       return new WordCardResponseDto({
         cardId: updatedUserWord.id,
         categoryId: updatedUserWord.userCategoryId || updatedUserWord.categoryId,
+        categoryName: updatedUserWord.userCategory?.categoryName || updatedUserWord.category?.categoryName,
         partOfSpeech: updatedUserWord.partOfSpeech,
         word: displayWord,
         imageUrl: displayImageUrl,
@@ -285,6 +293,7 @@ export class WordsService {
       return new WordCardResponseDto({
         cardId: newUserWord.id,
         categoryId: newUserWord.categoryId,
+        categoryName: newUserWord.category?.categoryName,
         partOfSpeech: newUserWord.partOfSpeech,
         word: displayWord,
         imageUrl: displayImageUrl,


### PR DESCRIPTION
## 📌 PR 요약
- 낱말 조회 API 응답에 카테고리 이름(categoryName) 필드 추가

## ⚡ 주요 변경 사항
- `WordCardResponseDto`에 `categoryName` 필드 추가
- 낱말 조회 시 카테고리 정보를 포함하여 응답하도록 수정
  - 기본 낱말(Word) 조회 시: `word.category.categoryName` 포함
  - 사용자 개인 낱말(UserWord) 조회 시: `userCategory.categoryName` 또는 `category.categoryName` 포함
  - 낱말 생성 후 응답에 카테고리 이름 포함
  - 낱말 수정 후 응답에 카테고리 이름 포함
- Repository에서 이미 category를 include하고 있어 추가 쿼리 없이 구현

## ✅ 테스트 내용
- Docker 환경에서 서버 실행 및 테스트 완료
- 낱말 조회 API 호출 시 categoryName이 정상적으로 응답에 포함되는지 확인

## 📎 관련 이슈
- Closed #1

## 📝 기타 참고사항
- 클라이언트에서 카테고리 ID로 별도 조회 없이 바로 카테고리 이름을 사용할 수 있어 네트워크 요청 감소 효과
- 기존 API 구조는 유지하면서 필드만 추가하여 하위 호환성 보장