### PR TITLE
[Feat] 최근 사용 낱말 조회 API 구현

### DIFF
--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -256,6 +256,49 @@ async function main() {
 
   console.log(`✅ 대화 이력 생성 완료`);
 
+  // ==========================================
+  // 1주일 이상 지난 대화 이력 생성 (필터링 테스트용)
+  // ==========================================
+  console.log('📅 오래된 대화 이력 생성 중 (1주일 초과)...');
+
+  const tenDaysAgo = new Date(new Date().getTime() - (10 * 24 * 60 * 60 * 1000)); // 10일 전
+  const fifteenDaysAgo = new Date(new Date().getTime() - (15 * 24 * 60 * 60 * 1000)); // 15일 전
+
+  // 10일 전 데이터 (이건 recent-words에서 제외되어야 함)
+  // 최근 데이터에 없는 고유한 단어 사용
+  await prisma.conversationHistory.create({
+    data: {
+      userId: user.id,
+      inputType: 'WORD_ONLY',
+      inputWords: [
+        { wordId: null, word: '오래된단어1', order: 1 },
+        { wordId: null, word: '테스트', order: 2 }
+      ],
+      suggestedSentences: ['오래된단어1 테스트'],
+      selectedSentence: '오래된단어1 테스트',
+      isOutputted: true,
+      createdAt: tenDaysAgo
+    }
+  });
+
+  // 15일 전 데이터 (이것도 recent-words에서 제외되어야 함)
+  await prisma.conversationHistory.create({
+    data: {
+      userId: user.id,
+      inputType: 'WORD_ONLY',
+      inputWords: [
+        { wordId: null, word: '오래된단어2', order: 1 },
+        { wordId: null, word: '검증', order: 2 }
+      ],
+      suggestedSentences: ['오래된단어2 검증'],
+      selectedSentence: '오래된단어2 검증',
+      isOutputted: true,
+      createdAt: fifteenDaysAgo
+    }
+  });
+
+  console.log(`✅ 오래된 대화 이력 2개 생성 완료 (10일 전, 15일 전)`);
+
   console.log('\n🎉 All data seeded successfully!');
 }
 

--- a/src/history/history.controller.js
+++ b/src/history/history.controller.js
@@ -2,7 +2,8 @@ import {
   getAllHistory,
   deleteHistory,
   deleteAllHistory,
-  getOfflineWords
+  getOfflineWords,
+  getRecentWords
 } from './history.service.js';
 import { ValidationError } from '../errors/app.error.js';
 
@@ -122,9 +123,36 @@ const getOfflineWordsController = async (req, res, next) => {
   }
 };
 
+const getRecentWordsController = async (req, res, next) => {
+  try {
+    const userId = req.user.id || req.user.userId;
+
+    if (!userId) {
+      console.error('❌ [HIS-06] 유저 ID를 찾을 수 없습니다. req.user:', req.user);
+      throw new ValidationError('인증 정보가 올바르지 않습니다');
+    }
+
+    console.log(`🔵 최근 사용 낱말 조회 요청: userId=${userId}`);
+
+    const words = await getRecentWords(userId);
+    console.log(`✅ 최근 사용 낱말 조회 완료: ${words.length}개`);
+
+    return res.status(200).success(
+      {
+        words,
+        totalCount: words.length
+      },
+      '최근 사용 낱말 조회 성공'
+    );
+  } catch (error) {
+    return next(error);
+  }
+};
+
 export {
   getHistoryController,
   deleteHistoryController,
   deleteAllHistoryController,
-  getOfflineWordsController
+  getOfflineWordsController,
+  getRecentWordsController
 };

--- a/src/history/history.repository.js
+++ b/src/history/history.repository.js
@@ -197,3 +197,20 @@ export const findFrequentWords = async (userId, frequentLimit = 80) => {
     return new Date(b.lastUsedAt) - new Date(a.lastUsedAt);
   });
 };
+
+// HIS-06: 최근 1주일 이내 사용한 낱말 조회 (시간순)
+export const findRecentUsedWords = async (userId) => {
+  const oneWeekAgo = new Date();
+  oneWeekAgo.setDate(oneWeekAgo.getDate() - 7);
+
+  return await prisma.conversationHistory.findMany({
+    where: {
+      userId,
+      isDeleted: false,
+      inputWords: { not: prisma.DbNull },
+      createdAt: { gte: oneWeekAgo }
+    },
+    select: { inputWords: true, createdAt: true },
+    orderBy: { createdAt: 'desc' }
+  });
+};

--- a/src/history/history.route.js
+++ b/src/history/history.route.js
@@ -3,7 +3,8 @@ import {
   getHistoryController,
   deleteHistoryController,
   deleteAllHistoryController,
-  getOfflineWordsController
+  getOfflineWordsController,
+  getRecentWordsController
 } from './history.controller.js';
 import { authenticate } from '../auth/middlewares/auth.middleware.js';
 
@@ -130,6 +131,64 @@ const router = express.Router();
  *         $ref: '#/components/responses/Unauthorized'
  */
 router.get('/offline-words', authenticate, getOfflineWordsController);
+
+/**
+ * @swagger
+ * /api/histories/recent-words:
+ *   get:
+ *     summary: 최근 사용 낱말 조회
+ *     description: |
+ *       최근 1주일 이내 사용한 낱말을 시간순으로 조회합니다.
+ *       중복된 낱말은 최초 사용 시간 기준으로 한 번만 표시됩니다.
+ *     tags: [History]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: 최근 사용 낱말 조회 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: true
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     words:
+ *                       type: array
+ *                       description: 최근 사용한 낱말 목록 (시간순)
+ *                       items:
+ *                         type: object
+ *                         properties:
+ *                           word:
+ *                             type: string
+ *                             description: 낱말
+ *                             example: "물"
+ *                           wordId:
+ *                             type: string
+ *                             format: uuid
+ *                             nullable: true
+ *                             description: 낱말 ID
+ *                             example: null
+ *                           usedAt:
+ *                             type: string
+ *                             format: date-time
+ *                             description: 사용 시각 (ISO 8601 형식)
+ *                             example: "2026-02-11T10:30:00.000Z"
+ *                     totalCount:
+ *                       type: integer
+ *                       description: 반환된 낱말 개수
+ *                       example: 15
+ *                 message:
+ *                   type: string
+ *                   example: "최근 사용 낱말 조회 성공"
+ *       401:
+ *         $ref: '#/components/responses/Unauthorized'
+ */
+router.get('/recent-words', authenticate, getRecentWordsController);
 
 /**
  * @swagger

--- a/src/history/history.service.js
+++ b/src/history/history.service.js
@@ -3,7 +3,8 @@ import {
   findById,
   deleteById,
   deleteAllByUserId,
-  findFrequentWords
+  findFrequentWords,
+  findRecentUsedWords
 } from './history.repository.js';
 import { NotFoundError } from '../errors/app.error.js';
 import { getFromCache, saveToCache } from '../utils/cache.util.js';
@@ -58,4 +59,40 @@ const getOfflineWords = async (userId, limit = 80) => { // 기본값 80
   };
 };
 
-export { getAllHistory, deleteHistory, deleteAllHistory, getOfflineWords };
+// 최근 1주일 이내 사용한 낱말 조회 (시간순)
+const getRecentWords = async (userId) => {
+  // DB에서 최근 1주일 대화 이력 조회
+  const histories = await findRecentUsedWords(userId);
+
+  // 단어 수집 (중복 제거, 시간순 유지)
+  const seenWords = new Set();
+  const recentWords = [];
+
+  for (const history of histories) {
+    const words = typeof history.inputWords === 'string'
+      ? JSON.parse(history.inputWords)
+      : history.inputWords;
+
+    if (Array.isArray(words)) {
+      for (const wordObj of words) {
+        const key = wordObj.word; // 단어 텍스트를 키로 사용
+
+        // 이미 본 단어면 건너뛰기 (최초 사용 시간 기준)
+        if (seenWords.has(key)) {
+          continue;
+        }
+
+        seenWords.add(key);
+        recentWords.push({
+          word: wordObj.word,
+          wordId: wordObj.wordId || null,
+          usedAt: history.createdAt
+        });
+      }
+    }
+  }
+
+  return recentWords;
+};
+
+export { getAllHistory, deleteHistory, deleteAllHistory, getOfflineWords, getRecentWords };

--- a/src/swagger/swagger.js
+++ b/src/swagger/swagger.js
@@ -24,7 +24,6 @@ const swaggerDefinition = {
       description:
         "학습 히스토리 관리 - 사용 기록 조회/삭제, 오프라인 낱말 조회",
     },
-    { name: "User", description: "유저 관련 API" },
     { name: "Words", description: "낱말 카드 API" },
     {
       name: "Routines - 자동 출력 문장 API",


### PR DESCRIPTION
## 📌 PR 요약
- 최근 1주일 이내 사용한 낱말 조회 API 추가 (HIS-06)

## ⚡ 주요 변경 사항
- **GET /api/histories/recent-words** 엔드포인트 추가
- 최근 7일 대화 이력에서 사용한 낱말 추출 (시간순, 중복 제거)
- Swagger 문서화 완료

## ✅ 테스트 내용
- Seed 데이터로 1주일 필터링 검증 완료
- API 호출 테스트 성공 (14개 단어 반환)
- Swagger UI 정상 작동 확인

## 📎 관련 이슈
- Closed #65

## 📝 기타 참고사항
- **테스트용 seed 데이터 추가됨**: 1주일 이전 데이터 2개 (필터링 검증용)
  - 테스트하려면 `npx prisma db seed` 실행 후 API 호출