### PR TITLE
[Fix] 낱말 순서 변경 첫 요청에서도 정상 동작하도록 수정

### DIFF
--- a/src/words/services/words.service.js
+++ b/src/words/services/words.service.js
@@ -354,26 +354,41 @@ export class WordsService {
       }
     }
 
-
     // 2. 기본 Word 참조가 있으면 스냅샷 생성 (아직 생성되지 않은 것만)
+    let createdUserWords = [];
     if (baseWordIds.length > 0) {
       const snapshotCount = await wordsRepository.countUserWordReferences(userId, categoryId);
       if (snapshotCount === 0) {
         // 스냅샷이 없으면 생성
-        await wordsRepository.createSnapshotFromWords(userId, categoryId);
+        createdUserWords = await wordsRepository.createSnapshotFromWords(userId, categoryId);
       }
     }
 
-    // 3. 업데이트할 displayOrder 목록 작성
-    const updates = orderedCardIds.map((cardId, index) => {
-      // 최종적으로 모든 cardId는 UserWord여야 함
-      return { userWordId: cardId, displayOrder: index };
+    // 3. Word.id를 UserWord.id로 매핑 (스냅샷이 생성된 경우)
+    const wordIdToUserWordIdMap = new Map();
+    if (createdUserWords.length > 0) {
+      createdUserWords.forEach(uw => {
+        if (uw.wordId) {
+          wordIdToUserWordIdMap.set(uw.wordId, uw.id);
+        }
+      });
+    }
+
+    // 4. orderedCardIds를 UserWord.id로 변환
+    const finalOrderedCardIds = orderedCardIds.map(cardId => {
+      // 이미 UserWord.id면 그대로, Word.id면 변환된 UserWord.id 사용
+      return wordIdToUserWordIdMap.get(cardId) || cardId;
     });
 
-    // 4. 대량 업데이트
+    // 5. 업데이트할 displayOrder 목록 작성
+    const updates = finalOrderedCardIds.map((userWordId, index) => {
+      return { userWordId, displayOrder: index };
+    });
+
+    // 6. 대량 업데이트
     await wordsRepository.bulkUpdateDisplayOrders(updates);
 
-    // 5. 변경된 낱말 목록 반환
+    // 7. 변경된 낱말 목록 반환
     const reorderedWords = await this.getWords(userId, categoryId, false);
     return reorderedWords.words;
   }


### PR DESCRIPTION
## 📌 PR 요약
- 낱말 순서 변경 API 첫 요청 시 순서 변경이 실패하는 버그 수정

## ⚡ 주요 변경 사항
- 스냅샷 생성 후 Word.id를 UserWord.id로 매핑하는 로직 추가
- orderedCardIds를 UserWord.id로 변환 후 bulkUpdateDisplayOrders 호출
- 첫 번째 reorder 요청에서도 정상적으로 순서 변경 적용되도록 개선

## ✅ 테스트 내용
- 로컬 환경에서 첫 번째 순서 변경 요청 테스트 완료
- 스냅샷 생성 및 순서 변경이 한 번의 요청으로 정상 처리됨
- 기존 UserWord가 있는 경우에도 정상 동작 확인

## 📎 관련 이슈
- Fixes #69

## 📝 기타 참고사항
- 기존에는 스냅샷 생성 후에도 Word.id를 그대로 사용하여 P2025 에러(레코드 없음) 발생
- 수정 후 createdUserWords를 활용하여 Word.id → UserWord.id 매핑 테이블 생성
- 사용자 경험 개선: 두 번 요청할 필요 없이 한 번에 순서 변경 완료