### PR TITLE
[hotfix]: docker 로그 용량 제한

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-
 services:
   # ==========================================
   # MySQL Database
@@ -20,8 +19,14 @@ services:
     networks:
       - moduwa_network
     command: --default-authentication-plugin=mysql_native_password --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+    # [수정] 로그 파일이 디스크를 점유하지 않도록 제한
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      test: [ "CMD", "mysqladmin", "ping", "-h", "localhost" ]
       timeout: 20s
       retries: 10
 
@@ -39,8 +44,14 @@ services:
     networks:
       - moduwa_network
     command: redis-server --appendonly yes
+    # [수정] 로그 용량 제한
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test: [ "CMD", "redis-cli", "ping" ]
       timeout: 3s
       retries: 5
 
@@ -57,9 +68,9 @@ services:
     environment:
       OPENAI_API_KEY: ${OPENAI_API_KEY}
       CORS_ORIGINS: http://localhost:3000
-      REDIS_HOST: redis       
-      REDIS_PORT: 6379        
-      REDIS_DB: 0             
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+      REDIS_DB: 0
     ports:
       - "8000:8000"
     volumes:
@@ -67,6 +78,12 @@ services:
     networks:
       - moduwa_network
     command: uvicorn main:app --host 0.0.0.0 --port 8000
+    # [수정] 로그 용량 제한
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
 
   # ==========================================
   # Backend API (Node.js + Express + Prisma)
@@ -107,12 +124,18 @@ services:
         condition: service_started
     networks:
       - moduwa_network
+    # [수정] 로그 용량 제한
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
     command: npm run dev
-
 
 volumes:
   mysql_data:
   redis_data:
+
 
 networks:
   moduwa_network:


### PR DESCRIPTION
## 📌 PR 요약
- docker 로그로 인한 메모리 부족 -> 용량 제한

## ⚡ 주요 변경 사항
- 서비스당 로그 파일의 이력(History) 개수 3개로 제한

## ✅ 테스트 내용
- local 테스트

## 📎 관련 이슈
- Closed #

## 📝 기타 참고사항
- 기타 이슈 또는 참고 자료
