### PR TITLE
[feat]: 반말 모드 기능 추가

### DIFF
--- a/src/ai-prediction/controllers/ai.style.controller.js
+++ b/src/ai-prediction/controllers/ai.style.controller.js
@@ -20,13 +20,26 @@ const transformStyleController = async (req, res, next) => {
     console.log('🟣 AI Style 요청 받음:', req.body);
 
     // 검증된 데이터 추출 (미들웨어에서 이미 검증 완료)
-    const { words, endingCards, refresh = false } = req.body;
+    const { words, endingCards, tone, refresh = false } = req.body;
     const userId = req.user?.userId; // 인증된 사용자 ID (학습 데이터 가중치 적용용)
 
+    // tone 우선 + endingCards 합성 정규화
+    let normalizedEndingCards = Array.isArray(endingCards) ? [...endingCards] : [];
+
+    if (tone) {
+      // endingCards 안에 존댓말/반말이 들어와도 tone이 우선이므로 제거
+      normalizedEndingCards = normalizedEndingCards.filter(
+        (card) => card !== '존댓말' && card !== '반말'
+      );
+
+      const toneCard = tone === 'HONORIFIC' ? '존댓말' : '반말';
+      normalizedEndingCards.unshift(toneCard);
+    }
+
     // 캐시 조회 (refresh가 false일 때만)
-    if (!refresh && words.length > 0 && endingCards.length > 0) {
+    if (!refresh && words.length > 0 && normalizedEndingCards.length > 0) {
       const cacheContext = { previousMessages: [] };
-      const cacheKey = generateCacheKey(words, cacheContext, 'styles', endingCards);
+      const cacheKey = generateCacheKey(words, cacheContext, 'styles', normalizedEndingCards);
       const cached = await getFromCache(cacheKey);
 
       if (cached?.sentences) {
@@ -54,12 +67,12 @@ const transformStyleController = async (req, res, next) => {
 
     // AI 문장 추천 호출 (userId 전달하여 학습 데이터 가중치 적용)
     console.log('🤖 FastAPI 호출:', { words, endingCards, refresh, userId });
-    const result = await transformSentenceStyle(words, endingCards, refresh, userId);
+    const result = await transformSentenceStyle(words, normalizedEndingCards, refresh, userId);
 
     // 캐시 저장 (원본 sentences만 저장, 사용자별 가중치 미적용)
-    if (words.length > 0 && endingCards.length > 0) {
+    if (words.length > 0 && normalizedEndingCards.length > 0) {
       const cacheContext = { previousMessages: [] };
-      const cacheKey = generateCacheKey(words, cacheContext, 'styles', endingCards);
+      const cacheKey = generateCacheKey(words, cacheContext, 'styles', normalizedEndingCards);
       await saveToCache(cacheKey, {
         words: result.words,
         endingCards: result.endingCards,

--- a/src/ai-prediction/middlewares/ai.validator.js
+++ b/src/ai-prediction/middlewares/ai.validator.js
@@ -35,7 +35,7 @@ export const validatePredictRequest = (req, res, next) => {
  * POST /api/ai/styles
  */
 export const validateStyleRequest = (req, res, next) => {
-  const { words, endingCards } = req.body;
+  const { words, endingCards, tone } = req.body;
 
   // 낱말 카드 검증
   if (!words || !Array.isArray(words) || words.length === 0) {
@@ -47,17 +47,31 @@ export const validateStyleRequest = (req, res, next) => {
     return next(new ValidationError('낱말 카드는 최대 10개까지 선택 가능합니다'));
   }
 
-  // 어미 선택 카드 검증 (배열, 1~5개)
-  if (!endingCards || !Array.isArray(endingCards)) {
-    return next(new ValidationError('어미 선택 카드를 최소 1개 이상 선택해주세요'));
+  const hasTone = typeof tone === 'string' && tone.length > 0;
+  const hasEndingCards = Array.isArray(endingCards);
+
+  // tone도 endingCards도 없으면 에러
+  if (!hasTone && !hasEndingCards) {
+    return next(new ValidationError('어미 선택 카드 또는 tone 중 하나는 반드시 제공해야 합니다'));
   }
 
-  if (endingCards.length === 0) {
-    return next(new ValidationError('어미 선택 카드를 최소 1개 이상 선택해주세요'));
+  // tone 값 검증 (있을 때만)
+  if (hasTone) {
+    const validTones = ['HONORIFIC', 'INFORMAL'];
+    if (!validTones.includes(tone)) {
+      return next(new ValidationError('tone은 HONORIFIC 또는 INFORMAL만 가능합니다'));
+    }
   }
 
-  if (endingCards.length > 5) {
-    return next(new ValidationError('어미 선택 카드는 최대 5개까지 선택 가능합니다'));
+  // endingCards 검증 (있을 때만)
+  if (hasEndingCards) {
+    if (endingCards.length === 0) {
+      return next(new ValidationError('어미 선택 카드를 최소 1개 이상 선택해주세요'));
+    }
+
+    if (endingCards.length > 5) {
+      return next(new ValidationError('어미 선택 카드는 최대 5개까지 선택 가능합니다'));
+    }
   }
 
   next();

--- a/src/ai-prediction/routes/ai.prediction.route.js
+++ b/src/ai-prediction/routes/ai.prediction.route.js
@@ -297,7 +297,7 @@ router.get('/contexts', authenticate, contextController);
  * /api/ai/styles:
  *   post:
  *     summary: 문장 스타일 변환
- *     description: 낱말 카드 + 어미 카드를 조합하여 특정 스타일의 문장을 생성합니다. predictions와 동일한 Cache-First 전략을 사용합니다.
+ *     description: 낱말 카드 + 어미 카드를 조합하여 특정 스타일의 문장을 생성합니다. predictions와 동일한 Cache-First 전략을 사용합니다. `endingCards`, `tone` 중 `tone`이 우선 적용됩니다.
  *     tags: [AI]
  *     security:
  *       - bearerAuth: []


### PR DESCRIPTION
## 📌 PR 요약
- AI 스타일 변환 API에 tone(HONORIFIC/INFORMAL) 파라미터를 추가하고 endingCards와 함께 사용할 수 있도록 확장

## ⚡ 주요 변경 사항
- validator에서 tone + endingCards 동시 허용 및 유효성 검증 로직 수정
- controller에서 tone 우선 정책으로 endingCards 정규화 처리
- 기존 서비스/캐시/개인화 로직은 유지

## ✅ 테스트 내용
- `tone`만, `endingCards`만, `tone+endingCards` 동시 요청 각각 정상 응답 확인
- refresh true/false에 따른 캐시 동작 확인

## 📎 관련 이슈
- Closed #

## 📝 기타 참고사항
- 