### PR TITLE
[hotfix]: docker-compose에 tts 파일 추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,6 +105,7 @@ services:
       REDIS_URL: redis://redis:6379
       KAKAO_CLIENT_ID: ${KAKAO_CLIENT_ID}
       KAKAO_REDIRECT_URI: ${KAKAO_REDIRECT_URI}
+      GOOGLE_APPLICATION_CREDENTIALS: /app/google-tts-credentials.json
       FASTAPI_URL: http://fastapi:8000
       NODE_ENV: ${NODE_ENV:-development}
       PORT: ${PORT:-3000}
@@ -114,6 +115,7 @@ services:
     volumes:
       - ./src:/app/src
       - ./prisma:/app/prisma
+      - ./google-tts-credentials.json:/app/google-tts-credentials.json:ro
       - /app/node_modules
     depends_on:
       mysql:


### PR DESCRIPTION
## 📌 PR 요약
- TTS 호출 시 크래시 원인이던 Google TTS credentials 파일 경로를 Docker 환경에 포함하도록 수정

## ⚡ 주요 변경 사항
- 컨테이너 내 `/app/google-tts-credentials.json` 경로로 반영하여 Google TTS 인증 실패 방지

## ✅ 테스트 내용
- EC2에서 `/api/ai/tts` 10회 연속 호출 시 모두 200 OK 및 mp3(audio/mpeg) 응답 정상 확인

## 📎 관련 이슈
- Closed #

## 📝 기타 참고사항
- 기타 이슈 또는 참고 자료
