### PR TITLE
[Fix] 낱말 카드 반복 버그 수정 및 카테고리 아이디 통일 확인

### DIFF
--- a/src/category/category.service.js
+++ b/src/category/category.service.js
@@ -75,12 +75,10 @@ export const getCategoryListService = async ({ userId }) => {
     });
 
     categories = await listUserCategories({ userId });
-  }
 
-    // 기본 UserCategory 생성 후, 각 카테고리별 Word를 UserWord로 복사
+    // 기본 UserCategory 생성 직후에만 복사
     const wordsRepo = (await import("../words/repositories/words.repository.js")).default;
     for (const userCategory of categories.filter(c => c.isDefault)) {
-      // 기본 카테고리 이름으로 Category 찾기
       const category = await prisma.category.findFirst({
         where: {
           categoryName: userCategory.categoryName,
@@ -88,10 +86,10 @@ export const getCategoryListService = async ({ userId }) => {
         }
       });
       if (category) {
-        // 해당 Category의 Word를 UserWord로 복사
         await wordsRepo.createSnapshotFromWords(userId, userCategory.id);
       }
     }
+  }
 
   return Promise.all(
     categories.map(async (c) => {

--- a/src/words/controllers/words.controller.js
+++ b/src/words/controllers/words.controller.js
@@ -11,6 +11,7 @@ export class WordsController {
   async getWords(req, res, next) {
     try {
       const userId = req.user?.userId;
+      const accountType = req.user?.accountType;
 
       const queryDto = new GetWordsQueryDto({
         categoryId: req.query.categoryId,
@@ -19,6 +20,7 @@ export class WordsController {
 
       const result = await wordsService.getWords(
         userId,
+        accountType,
         queryDto.categoryId,
         queryDto.onlyFavorite
       );

--- a/src/words/routes/words.route.js
+++ b/src/words/routes/words.route.js
@@ -16,9 +16,10 @@ const router = express.Router();
  *   get:
  *     summary: 낱말 카드 조회
  *     description: |
- *       낱말 카드 목록을 조회합니다.
- *       토큰이 있으면 사용자별 낱말(즐겨찾기/개인화 포함), 없으면 기본 낱말만 반환합니다.
- *       categoryId가 있으면 data.category(카테고리 이름)도 함께 반환됩니다.
+*       낱말 카드 목록을 조회합니다.
+*       토큰이 있으면 게스트/소셜 계정 모두 사용자별 낱말(즐겨찾기/개인화 포함)을 조회합니다.
+*       토큰이 없으면 기본 낱말만 반환합니다.
+*       categoryId가 있으면 data.category(카테고리 이름)도 함께 반환됩니다.
  *     tags: [Words]
  *     parameters:
  *       - in: query

--- a/src/words/services/words.service.js
+++ b/src/words/services/words.service.js
@@ -9,13 +9,13 @@ export class WordsService {
     /**
      * 내부용: 전체 낱말 카드 목록 생성 (categoryId 없이)
      */
-    async _getAllWordCards(userId, onlyFavorite = false) {
+    async _getAllWordCards(userId, accountType, onlyFavorite = false) {
       const wordCards = [];
       let categoryNameToUserCategoryIdMap = new Map();
       let categoryNameToCategoryIdMap = new Map();
       let hasUserCategories = false;
 
-      if (userId) {
+      if (userId && accountType !== 'GUEST') {
         const userCategories = await wordsRepository.findAllUserCategories(userId);
         if (userCategories.length > 0) {
           hasUserCategories = true;
@@ -34,7 +34,7 @@ export class WordsService {
       let userWords = [];
       const userWordMap = new Map();
       const deletedWordIds = new Set();
-      if (userId) {
+      if (userId && accountType !== 'GUEST') {
         userWords = await wordsRepository.findUserWords(userId, null, onlyFavorite, true);
         userWords.forEach(uw => {
           if (uw.wordId) userWordMap.set(uw.wordId, uw);
@@ -45,8 +45,8 @@ export class WordsService {
       }
 
       // 소셜 로그인(유저가 존재) 시에는 기본 Word를 반환하지 않고 UserWord만 반환
-      // 게스트(유저 없음)일 때만 기본 Word 반환
-      if (!onlyFavorite && !userId) {
+      // 게스트(유저 없음 또는 accountType이 GUEST)일 때 기본 Word 반환
+      if (!onlyFavorite && (!userId || accountType === 'GUEST')) {
         const words = await wordsRepository.findWords(null, userId);
         words.forEach((word, index) => {
           const wordCategoryName = word.category?.categoryName;
@@ -101,20 +101,20 @@ export class WordsService {
   /**
    * 다음 displayOrder 계산 (기본 Word + UserWord 모두 고려)
    * @param {string} userId
+   * @param {string} accountType
    * @param {string} categoryId
    * @returns {Promise<number>}
    */
-  async getNextDisplayOrder(userId, categoryId) {
+  async getNextDisplayOrder(userId, accountType, categoryId) {
     // 1. UserWord 조회 (삭제된 것 제외)
-    const userWords = await wordsRepository.findUserWords(userId, categoryId, false, false);
-    
-    // 2. UserWord가 있으면 최대값 + 1 반환
-    if (userWords.length > 0) {
-      const maxOrder = Math.max(...userWords.map(w => w.displayOrder));
-      return maxOrder + 1;
+    if (accountType !== 'GUEST') {
+      const userWords = await wordsRepository.findUserWords(userId, categoryId, false, false);
+      if (userWords.length > 0) {
+        const maxOrder = Math.max(...userWords.map(w => w.displayOrder));
+        return maxOrder + 1;
+      }
     }
-    
-    // 3. UserWord가 없으면 기본 Word 개수 반환
+    // 게스트이거나 UserWord가 없으면 기본 Word 개수 반환
     const words = await wordsRepository.findWords(categoryId, userId);
     return words.length;
   }
@@ -124,13 +124,14 @@ export class WordsService {
    * 기본 낱말(Word) + 개인 낱말(UserWord) 통합 반환
    * 
    * @param {string} userId
+   * @param {string} accountType
    * @param {string|null} categoryId - Category.id 또는 UserCategory.id
    * @param {boolean} onlyFavorite
    * @returns {Promise<Object>} { category, words }
    */
-  async getWords(userId, categoryId = null, onlyFavorite = false) {
+  async getWords(userId, accountType, categoryId = null, onlyFavorite = false) {
     // 1. 전체 낱말 목록 생성 (categoryId 없이)
-    const allWords = await this._getAllWordCards(userId, onlyFavorite);
+    const allWords = await this._getAllWordCards(userId, accountType, onlyFavorite);
 
     // 2. categoryId가 없으면 전체 반환
     if (!categoryId) {

--- a/src/words/services/words.service.js
+++ b/src/words/services/words.service.js
@@ -34,7 +34,7 @@ export class WordsService {
       let userWords = [];
       const userWordMap = new Map();
       const deletedWordIds = new Set();
-      if (userId && accountType !== 'GUEST') {
+      if (userId) {
         userWords = await wordsRepository.findUserWords(userId, null, onlyFavorite, true);
         userWords.forEach(uw => {
           if (uw.wordId) userWordMap.set(uw.wordId, uw);
@@ -44,17 +44,14 @@ export class WordsService {
         });
       }
 
-      // 소셜 로그인(유저가 존재) 시에는 기본 Word를 반환하지 않고 UserWord만 반환
-      // 게스트(유저 없음 또는 accountType이 GUEST)일 때 기본 Word 반환
-      if (!onlyFavorite && (!userId || accountType === 'GUEST')) {
-        const words = await wordsRepository.findWords(null, userId);
+      // 소셜/게스트 로그인(유저가 존재) 시에는 UserWord 기반, 비회원(토큰 없음)만 기본 Word 반환
+      if (!onlyFavorite && !userId && !accountType) {
+        const words = await wordsRepository.findWords();
         words.forEach((word, index) => {
-          const wordCategoryName = word.category?.categoryName;
-          let mappedCategoryId = categoryNameToCategoryIdMap.get(wordCategoryName) || word.categoryId;
           wordCards.push(new WordCardResponseDto({
             cardId: word.id,
-            categoryId: mappedCategoryId,
-            categoryName: wordCategoryName,
+            categoryId: word.categoryId,
+            categoryName: word.category?.categoryName,
             partOfSpeech: word.partOfSpeech,
             word: word.word,
             imageUrl: word.imageUrl,


### PR DESCRIPTION
## 📌 PR 요약
- 로그인 시 낱말 카드가 복사되는 버그 수정
- 게스트 계정도 기본 카테고리-기본 낱말 복사해 생성 
- 카테고리 조회와 낱말 조회의 category.id 통일

## ⚡ 주요 변경 사항
- 카테고리 생성 로직 내부로 낱말 생성 로직을 옮겨와 로그인 시 낱말 복사가 반복되는 버그 수정
- 게스트 계정도 낱말 조회 시 UserWord 데이터로 조회

## ✅ 테스트 내용
- 게스트 계정 생성 -> 카테고리 생성 -> 낱말 생성 확인
- 로그인 시 낱말 복사 버그 잡혔는지 확인
- 카테고리 조회 시 category.id와 낱말 조회시 category.id가 동일한지 확인 

## 📎 관련 이슈
-

## 📝 기타 참고사항
- 기타 이슈 또는 참고 자료