### PR TITLE
[Fix] AI-05 confidence 순위 기반 전환 및 context 파라미터 추가

### DIFF
--- a/src/ai-prediction/controllers/ai.style.controller.js
+++ b/src/ai-prediction/controllers/ai.style.controller.js
@@ -19,7 +19,7 @@ const transformStyleController = async (req, res, next) => {
     console.log('🟣 AI Style 요청 받음:', req.body);
 
     // 검증된 데이터 추출 (미들웨어에서 이미 검증 완료)
-    const { words, endingCards, tone, refresh = false } = req.body;
+    const { words, endingCards, tone, context, refresh = false } = req.body;
     const userId = req.user?.userId; // 인증된 사용자 ID (학습 데이터 가중치 적용용)
 
     // endingCards 정규화 (tone은 별도 파라미터로 FastAPI에 직접 전달)
@@ -27,7 +27,7 @@ const transformStyleController = async (req, res, next) => {
 
     // 캐시 조회 (refresh가 false일 때만)
     if (!refresh && words.length > 0 && (normalizedEndingCards.length > 0 || tone)) {
-      const cacheContext = { previousMessages: [] };
+      const cacheContext = { previousMessages: context?.previousMessages || [] };
       const cacheKey = generateCacheKey(words, cacheContext, 'styles', normalizedEndingCards, tone);
       const cached = await getFromCache(cacheKey);
 
@@ -35,11 +35,8 @@ const transformStyleController = async (req, res, next) => {
         console.log('💾 캐시에서 반환');
 
         // 캐시된 결과에도 사용자별 학습 데이터 가중치 적용
-        const cachedWithConfidence = cached.sentences.map(sentence => ({
-          sentence,
-          confidence: 0.5 // 캐시된 데이터는 기본 confidence 값 사용
-        }));
-        const rankedCached = await rankByLearningData(cachedWithConfidence, userId);
+        // cached.sentences는 {sentence, confidence}[] 형태로 저장됨 (AI-01과 동일)
+        const rankedCached = await rankByLearningData(cached.sentences, userId);
         const finalSentences = rankedCached.map(pred => pred.sentence);
 
         return res.status(200).success(
@@ -55,13 +52,13 @@ const transformStyleController = async (req, res, next) => {
       }
     }
 
-    // AI 문장 추천 호출 (userId, tone 전달)
-    console.log('🤖 FastAPI 호출:', { words, endingCards: normalizedEndingCards, tone, refresh, userId });
-    const result = await transformSentenceStyle(words, normalizedEndingCards, refresh, userId, tone);
+    // AI 문장 추천 호출 (userId, tone, context 전달)
+    console.log('🤖 FastAPI 호출:', { words, endingCards: normalizedEndingCards, tone, context, refresh, userId });
+    const result = await transformSentenceStyle(words, normalizedEndingCards, refresh, userId, tone, context);
 
     // 캐시 저장 (원본 sentences만 저장, 사용자별 가중치 미적용)
     if (words.length > 0 && normalizedEndingCards.length > 0) {
-      const cacheContext = { previousMessages: [] };
+      const cacheContext = { previousMessages: context?.previousMessages || [] };
       const cacheKey = generateCacheKey(words, cacheContext, 'styles', normalizedEndingCards, tone);
       await saveToCache(cacheKey, {
         words: result.words,

--- a/src/ai-prediction/routes/ai.prediction.route.js
+++ b/src/ai-prediction/routes/ai.prediction.route.js
@@ -321,18 +321,20 @@ router.get('/contexts', authenticate, contextController);
  *   post:
  *     summary: 문장 스타일 변환
  *     description: |
- *       낱말 카드 + 어미 카드를 조합하여 특정 스타일의 문장을 생성합니다. predictions와 동일한 Cache-First 전략을 사용합니다.
+ *       낱말 카드 + 어미 카드를 조합하여 특정 스타일의 문장을 생성합니다. AI-01(`predictions`)과 동일한 Cache-First 전략 및 순위 기반 가중치 적용.
  *
- *       **`tone`** — 반말/존댓말 토글 (기기 내 설정값 반영)
- *
- *       > 토글 OFF → `HONORIFIC` (존댓말, 기본값) / 토글 ON → `INFORMAL` (반말)
- *
- *       **`endingCards`** — 어미 선택 카드 (문장 스타일 지정)
+ *       **`endingCards`** — 어미 선택 카드 (문장 스타일 지정). **필수**
  *
  *       > `하고 싶어요` / `하기 싫어요` / `질문` / `해주세요` / `합시다` 및 사용자 커스텀 어미 가능.
  *       > LLM이 어미의 의미를 해석하여 자연스러운 문장으로 변환합니다.
  *
+ *       **`tone`** — 반말/존댓말 토글 (기기 내 설정값 반영). 선택사항
+ *
+ *       > 토글 OFF → `HONORIFIC` (존댓말, 기본값) / 토글 ON → `INFORMAL` (반말)
+ *
  *       두 파라미터는 **독립적이며 동시에 사용 가능**합니다. `tone`은 반말/존댓말만 제어하고, `endingCards`는 문장의 의도/어미를 제어합니다.
+ *
+ *       **`context`** — 대화 맥락 정보 (선택사항). AI-01과 동일하게 `previousMessages`가 캐시 키에 포함됩니다.
  *     tags: [AI]
  *     security:
  *       - bearerAuth: []
@@ -344,11 +346,15 @@ router.get('/contexts', authenticate, contextController);
  *             type: object
  *             required:
  *               - words
- *             description: "`tone`과 `endingCards`는 독립적인 파라미터입니다. `tone`은 반말/존댓말만 제어하고, `endingCards`는 문장의 의도와 어미 스타일을 제어합니다. 둘 다 없으면 에러입니다."
+ *               - endingCards
+ *             description: "`tone`과 `endingCards`는 독립적인 파라미터입니다. `tone`은 반말/존댓말만 제어하고, `endingCards`는 문장의 의도와 어미 스타일을 제어합니다."
  *             example:
  *               words: ["밥", "먹다"]
  *               endingCards: ["질문"]
  *               tone: "INFORMAL"
+ *               context:
+ *                 currentTime: "2026년 1월 28일 (화) 14:30"
+ *                 previousMessages: ["약 먹어야 해", "오늘 기분 좋아"]
  *               refresh: false
  *             properties:
  *               words:
@@ -364,7 +370,21 @@ router.get('/contexts', authenticate, contextController);
  *                   type: string
  *                 minItems: 1
  *                 maxItems: 5
- *                 description: "선택한 어미 카드 배열 (최대 5개). tone 없이 사용 시 필수. 기본 카드: 하고 싶어요, 하기 싫어요, 질문, 해주세요, 합시다. tone과 독립적으로 동시 사용 가능."
+ *                 description: "선택한 어미 카드 배열 (필수, 최대 5개). 기본 카드: 하고 싶어요, 하기 싫어요, 질문, 해주세요, 합시다. tone과 독립적으로 동시 사용 가능."
+ *               context:
+ *                 type: object
+ *                 description: 대화 맥락 정보 (선택사항). AI-01과 동일하게 캐시 키에 포함됩니다.
+ *                 properties:
+ *                   currentTime:
+ *                     type: string
+ *                     description: 현재 시각 (한국 시각 형식)
+ *                     example: "2026년 1월 28일 (화) 14:30"
+ *                   previousMessages:
+ *                     type: array
+ *                     items:
+ *                       type: string
+ *                     description: 최근 대화 기록 (최대 10분 이내)
+ *                     example: ["약 먹어야 해", "오늘 기분 좋아"]
  *               tone:
  *                 type: string
  *                 enum: [HONORIFIC, INFORMAL]

--- a/src/ai-prediction/services/ai.style.service.js
+++ b/src/ai-prediction/services/ai.style.service.js
@@ -15,7 +15,7 @@ const FASTAPI_URL = process.env.FASTAPI_URL || 'http://fastapi:8000';
  * @param {string} userId - 사용자 ID (학습 데이터 가중치 적용용)
  * @returns {Promise<Object>} 추천 문장 3개 (빈도수 가중치 적용 후 정렬) + rawSentences
  */
-const transformSentenceStyle = async (words, endingCards, refresh = false, userId = null, tone = null) => {
+const transformSentenceStyle = async (words, endingCards, refresh = false, userId = null, tone = null, context = {}) => {
   // 타임아웃 처리 (10초)
   const timeoutPromise = new Promise((_, reject) => {
     setTimeout(() => {
@@ -32,6 +32,10 @@ const transformSentenceStyle = async (words, endingCards, refresh = false, userI
     body: JSON.stringify({
       words,
       endingCards,
+      context: {
+        currentTime: context?.currentTime,
+        previousMessages: (context?.previousMessages || []).slice(-3)
+      },
       ...(tone && { tone }), // tone이 있을 때만 포함
       refresh
     })
@@ -52,9 +56,11 @@ const transformSentenceStyle = async (words, endingCards, refresh = false, userI
   }
 
   // 1단계: 응답 정규화 (confidence 값 추가)
-  const normalizedSentences = result.sentences.slice(0, 3).map(sentence => ({
+  // FastAPI 응답 순서를 순위로 활용 (AI-01과 동일 방식)
+  const rankScores = [0.6, 0.5, 0.4];
+  const normalizedSentences = result.sentences.slice(0, 3).map((sentence, index) => ({
     sentence,
-    confidence: 0.5 // Style API는 confidence 값이 없으므로 기본값 사용
+    confidence: rankScores[index] ?? 0.4
   }));
 
   // 2단계: 학습 데이터 가중치 적용 및 재정렬
@@ -66,7 +72,7 @@ const transformSentenceStyle = async (words, endingCards, refresh = false, userI
     words,
     endingCards,
     sentences: rankedSentences.map(pred => pred.sentence), // 가중치 적용된 문장
-    rawSentences: normalizedSentences.map(pred => pred.sentence), // 캐싱용 원본
+    rawSentences: normalizedSentences, // 캐싱용 원본 (confidence 포함, AI-01과 동일)
     fromCache: result.fromCache || false
   };
 };


### PR DESCRIPTION
## 📌 PR 요약
- AI-05(`/api/ai/styles`)의 버그 3건 수정 및 AI-01과 로직 완전 통일

## ⚡ 주요 변경 사항
- **confidence 버그 수정**: 전 문장 0.5 고정 → 순위 기반 점수 [0.6, 0.5, 0.4]
- **context 추가**: `currentTime` + `previousMessages` FastAPI 전달 (캐시 키 포함)
- **캐시 저장 형식 수정**: `string[]` → `{sentence, confidence}[]` (캐시 HIT 시 신뢰도 보존)
- **문서 동기화**: swagger

## ✅ 테스트 내용
- AI-05 캐시 MISS → 순위 점수 정상 부여 확인
- AI-05 캐시 HIT → 동일 confidence 유지 확인
- context 포함 시 캐시 키 분리 확인

## 📎 관련 이슈
- Closed #105

## 📝 기타 참고사항